### PR TITLE
[Refactor]: User 모델의 어노테이션 중복 제거 및 Lombok 적용

### DIFF
--- a/src/main/java/go/seoul/serv/model/User.java
+++ b/src/main/java/go/seoul/serv/model/User.java
@@ -5,25 +5,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.Id;
 
 @Data
 @NoArgsConstructor
 @Entity
 public class User {
     @jakarta.persistence.Id
-    @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;
     private String email;
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public Long getId() {
-        return id;
-    }
 }


### PR DESCRIPTION
- User 엔티티 클래스에 중복된 @Id 어노테이션을 제거
- JPA가 사용하는 jakarta.persistence.Id만을 사용